### PR TITLE
Show storyteller description in info-window

### DIFF
--- a/Languages/English/Keyed/Text.xml
+++ b/Languages/English/Keyed/Text.xml
@@ -24,7 +24,7 @@
   <changeOnYearChanceTooltip>Percentage chance that the storyteller changes after a new year.</changeOnYearChanceTooltip>
   
   <StorytellerChangeLetterTitle>Storyteller Changed</StorytellerChangeLetterTitle>
-  <StorytellerChangeLetterDescription>The storyteller has changed!\n Now {0} is in charge!</StorytellerChangeLetterDescription>
+  <StorytellerChangeLetterDescription>The storyteller has changed!\n Now {0} is in charge!\n\n{1}</StorytellerChangeLetterDescription>
   
   <xAsLikely> times as likely</xAsLikely>
 

--- a/Source/Utils/NotifierUtil.cs
+++ b/Source/Utils/NotifierUtil.cs
@@ -10,9 +10,9 @@ namespace Hotseat.Utils
             Find.LetterStack.ReceiveLetter("StorytellerChangeLetterTitle".Translate(), GetStorytellerChangeLetterDescription(), LetterDefOf.NeutralEvent, null);
         }
 
-        private static string GetStorytellerChangeLetterDescription()
+        private static TaggedString GetStorytellerChangeLetterDescription()
         {   
-            return string.Format("StorytellerChangeLetterDescription".Translate(), Current.Game.storyteller.def.label);
+            return "StorytellerChangeLetterDescription".Translate(Current.Game.storyteller.def.label, Current.Game.storyteller.def.description);
         }
     }
 }


### PR DESCRIPTION
Small edit to make the story-teller description show in the notification about changed storyteller.
I have so many storytellers so this would make it easier instead of having to open the settings to read up on the new storyteller :)
Great mod, btw!